### PR TITLE
Fix polyline double margin

### DIFF
--- a/Shapes-RectTransform/Assets/_PackageRoot/Scripts/UI/PolylineRectTransform.cs
+++ b/Shapes-RectTransform/Assets/_PackageRoot/Scripts/UI/PolylineRectTransform.cs
@@ -55,8 +55,8 @@ public class PolylineRectTransform : UIBehaviourShape<Polyline>
         Vector3 max = Vector3.one * float.MinValue;
         foreach (var pt in polyline.points)
         {
-            min = Vector3.Min(min, pt.point - Vector3.one * (polyline.Thickness * pt.thickness));
-            max = Vector3.Max(max, pt.point + Vector3.one * (polyline.Thickness * pt.thickness));
+            min = Vector3.Min(min, pt.point - Vector3.one * (polyline.Thickness * pt.thickness) / 2f);
+            max = Vector3.Max(max, pt.point + Vector3.one * (polyline.Thickness * pt.thickness) / 2f);
         }
 
         if (polyline.Geometry == PolylineGeometry.Flat2D)


### PR DESCRIPTION
The edge of the rect needs to be at least one half the line width away from the center of the line.  This is still an underestimate in many situations, but introduces no new conditions for overestimates (miter edges be sharp).