### PR TITLE
DiscRectTransform no longer requires 1:1 pixels to units

### DIFF
--- a/Shapes-RectTransform/Assets/_PackageRoot/Scripts/UI/DiscRectTransform.cs
+++ b/Shapes-RectTransform/Assets/_PackageRoot/Scripts/UI/DiscRectTransform.cs
@@ -14,12 +14,13 @@ public class DiscRectTransform : UIBehaviourShapeNested<Disc>
         var rtPivot = rectTransform.pivot;
         var rtSize = rectTransform.rect.size;
         var rtCenter = rtPivot * rtSize;
+        var discThickness = disc.ThicknessSpace == ThicknessSpace.Pixels ? disc.Thickness : 0f;
 
         disc.transform.localPosition = -(rtCenter - rtSize / 2);
 
-        disc.RadiusSpace = ThicknessSpace.Meters;
+        disc.RadiusSpace = ThicknessSpace.Pixels;
 
-        if (mode == Mode.Fill) disc.Radius = Mathf.Max(rtSize.x, rtSize.y) / 2;
-        if (mode == Mode.Fit) disc.Radius = Mathf.Min(rtSize.x, rtSize.y) / 2;
+        if (mode == Mode.Fill) disc.Radius = (Mathf.Max(rtSize.x, rtSize.y) - discThickness) / 2f;
+        if (mode == Mode.Fit) disc.Radius = (Mathf.Min(rtSize.x, rtSize.y) - discThickness) / 2f;
     }
 }


### PR DESCRIPTION
RectTransform dimensions are measured in canvas pixels.
While I'm here, might as well support thickness.